### PR TITLE
Creating PsalmsJwtExtension

### DIFF
--- a/Psalms.AspNetCore.Auth.Jwt/Class1.cs
+++ b/Psalms.AspNetCore.Auth.Jwt/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace Psalms.AspNetCore.Auth.Jwt;
-
-public class Class1
-{
-
-}

--- a/Psalms.AspNetCore.Auth.Jwt/Extensions/PsalmsJwtExtension.cs
+++ b/Psalms.AspNetCore.Auth.Jwt/Extensions/PsalmsJwtExtension.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
+
+namespace Psalms.AspNetCore.Auth.Jwt;
+
+public static class PsalmsJwtExtension
+{
+    public static IServiceCollection AddPsalmsJwtAuthentication(this IServiceCollection service, IConfiguration configuration)
+    {
+        var key = configuration["JWT:Key"] ?? throw new Exception("Key not found");
+
+        service.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(options =>
+            {
+                options.TokenValidationParameters = new TokenValidationParameters
+                {
+                    ValidateIssuer           = !string.IsNullOrEmpty(configuration["JWT:Issuer"]),
+                    ValidateAudience         = !string.IsNullOrEmpty(configuration["JWT:Audience"]),
+                    ValidateLifetime         = !string.IsNullOrEmpty(configuration["JWT:Expires"]),
+                    ValidateIssuerSigningKey = !string.IsNullOrEmpty(key),
+                    IssuerSigningKey         = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key))
+                };
+            });
+        return service;
+    }
+}

--- a/Psalms.AspNetCore.Auth.Jwt/Psalms.AspNetCore.Auth.Jwt.csproj
+++ b/Psalms.AspNetCore.Auth.Jwt/Psalms.AspNetCore.Auth.Jwt.csproj
@@ -6,4 +6,10 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.7" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
# ✨ Add JWT Authentication Extension

## Summary

This pull request introduces the `PsalmsJwtExtension` class, a static extension method that encapsulates the configuration of JWT authentication for ASP.NET Core applications.

## What's Included

- ✅ New class: `PsalmsJwtExtension`
- 📦 Extension method: `AddPsalmsJwtAuthentication(IServiceCollection, IConfiguration)`
- 🔐 Simplifies the setup of JWT authentication using `Microsoft.AspNetCore.Authentication.JwtBearer`

## How It Works

The `AddPsalmsJwtAuthentication` method reads configuration values from the application's `IConfiguration` (typically from `appsettings.json` or environment variables):

- `JWT:Key` (required): Secret key used for signing tokens.
- `JWT:Issuer` (optional): Token issuer.
- `JWT:Audience` (optional): Token audience.
- `JWT:Expires` (optional): Used to determine if `ValidateLifetime` should be enabled.

It then configures the `TokenValidationParameters` accordingly, registering `JwtBearer` as the default authentication scheme.

## Example Usage

```csharp
services.AddPsalmsJwtAuthentication(Configuration);
```

## Benefits
🔄 Reusable and clean configuration

⚙️ Encourages consistency across projects

📁 Keeps Startup.cs or Program.cs minimal and maintainable
