### PR TITLE
Creating RefreshToken System

### DIFF
--- a/Psalms.AspNetCore.Auth.Jwt/Extensions/PsalmsJwtExtension.cs
+++ b/Psalms.AspNetCore.Auth.Jwt/Extensions/PsalmsJwtExtension.cs
@@ -1,29 +1,18 @@
 ﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.IdentityModel.Tokens;
-using System.Text;
+using Psalms.Auth.Jwt;
 
 namespace Psalms.AspNetCore.Auth.Jwt;
 
 public static class PsalmsJwtExtension
 {
     public static IServiceCollection AddPsalmsJwtAuthentication(this IServiceCollection service, IConfiguration configuration)
-    {
-        var key = configuration["JWT:Key"] ?? throw new Exception("Key not found");
-
+    {     
         service.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             .AddJwtBearer(options =>
-            {
-                options.TokenValidationParameters = new TokenValidationParameters
-                {
-                    ValidateIssuer           = !string.IsNullOrEmpty(configuration["JWT:Issuer"]),
-                    ValidateAudience         = !string.IsNullOrEmpty(configuration["JWT:Audience"]),
-                    ValidateLifetime         = !string.IsNullOrEmpty(configuration["JWT:Expires"]),
-                    ValidateIssuerSigningKey = !string.IsNullOrEmpty(key),
-                    IssuerSigningKey         = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key))
-                };
-            });
+                options.TokenValidationParameters = PsalmsJwtTokenService.GetValidationParameters(configuration));
+   
         return service;
     }
 }

--- a/Psalms.AspNetCore.Auth.Jwt/Interfaces/IPsalmsRefreshTokenEFContext.cs
+++ b/Psalms.AspNetCore.Auth.Jwt/Interfaces/IPsalmsRefreshTokenEFContext.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Psalms.AspNetCore.Auth.Jwt.Models;
+
+namespace Psalms.AspNetCore.Auth.Jwt.Interfaces;
+    
+public interface IPsalmsRefreshTokenEFContext
+{
+    DbSet<RefreshTokenModel> Refreshes { get; set; }
+    Task ConfirmChangesAsync();
+}

--- a/Psalms.AspNetCore.Auth.Jwt/Models/AuthResponse.cs
+++ b/Psalms.AspNetCore.Auth.Jwt/Models/AuthResponse.cs
@@ -1,0 +1,18 @@
+﻿namespace Psalms.AspNetCore.Auth.Jwt.Models;
+
+/// <summary>
+/// Represents the response returned after a successful authentication or token refresh,
+/// containing both access and refresh tokens.
+/// </summary>
+public class AuthResponse
+{
+    /// <summary>
+    /// Gets or sets the generated access token (JWT) used for authenticated requests.
+    /// </summary>
+    public string? AccessToken { get; set; }
+
+    /// <summary>
+    /// Gets or sets the associated refresh token model, used to obtain a new access token when the current one expires.
+    /// </summary>
+    public RefreshTokenModel? RefreshTokenModel { get; set; }
+}

--- a/Psalms.AspNetCore.Auth.Jwt/Models/RefreshTokenModel.cs
+++ b/Psalms.AspNetCore.Auth.Jwt/Models/RefreshTokenModel.cs
@@ -1,0 +1,9 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Psalms.AspNetCore.Auth.Jwt.Models;
+
+public class RefreshTokenModel
+{
+    [Key]
+    public string? RefreshToken { get; set; } 
+}

--- a/Psalms.AspNetCore.Auth.Jwt/Psalms.AspNetCore.Auth.Jwt.csproj
+++ b/Psalms.AspNetCore.Auth.Jwt/Psalms.AspNetCore.Auth.Jwt.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.7" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.7" />
   </ItemGroup>

--- a/Psalms.AspNetCore.Auth.Jwt/Repository/RefreshToken/EF/RefreshTokenRepositoryEF.cs
+++ b/Psalms.AspNetCore.Auth.Jwt/Repository/RefreshToken/EF/RefreshTokenRepositoryEF.cs
@@ -1,0 +1,23 @@
+﻿using Psalms.AspNetCore.Auth.Jwt.Models;
+using Psalms.AspNetCore.Auth.Jwt.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Psalms.AspNetCore.Auth.Jwt.Repository.RefreshToken;
+
+internal class EFRefreshTokenRepository(IPsalmsRefreshTokenEFContext context) : IPsalmsRefreshTokenRepository
+{
+    public async Task DeleteRefreshTokenAsync(string refreshToken)
+    {
+        context.Refreshes.Remove(await context.Refreshes.FirstAsync());
+        await context.ConfirmChangesAsync();
+    }
+
+    public async Task<bool> RefreshTokenExistAsync(string refreshToken)
+        => await context.Refreshes.AnyAsync(x => x.RefreshToken == refreshToken);
+
+    public async Task SaveRefreshTokenAsync(RefreshTokenModel model)
+    {
+        await context.Refreshes.AddAsync(model);
+        await context.ConfirmChangesAsync();
+    }
+}

--- a/Psalms.AspNetCore.Auth.Jwt/Repository/RefreshToken/IPsalmsRefreshTokenRepository.cs
+++ b/Psalms.AspNetCore.Auth.Jwt/Repository/RefreshToken/IPsalmsRefreshTokenRepository.cs
@@ -1,0 +1,30 @@
+﻿using Psalms.AspNetCore.Auth.Jwt.Models;
+
+namespace Psalms.AspNetCore.Auth.Jwt.Repository.RefreshToken;
+
+/// <summary>
+/// Interface for managing refresh tokens in a persistent storage.
+/// </summary>
+public interface IPsalmsRefreshTokenRepository
+{
+    /// <summary>
+    /// Saves a new refresh token to the storage.
+    /// </summary>
+    /// <param name="model">The refresh token model to be saved.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task SaveRefreshTokenAsync(RefreshTokenModel model);
+
+    /// <summary>
+    /// Deletes an existing refresh token from the storage.
+    /// </summary>
+    /// <param name="token">The refresh token to be deleted.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task DeleteRefreshTokenAsync(string token);
+
+    /// <summary>
+    /// Checks if a given refresh token exists in the storage.
+    /// </summary>
+    /// <param name="token">The refresh token to be verified.</param>
+    /// <returns>A task that returns true if the token exists, otherwise false.</returns>
+    Task<bool> RefreshTokenExistAsync(string token);
+}

--- a/Psalms.AspNetCore.Auth.Jwt/Repository/RefreshToken/Memory/RefreshTokenRepositoryInMemory.cs
+++ b/Psalms.AspNetCore.Auth.Jwt/Repository/RefreshToken/Memory/RefreshTokenRepositoryInMemory.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Extensions.Caching.Memory;
+using Psalms.AspNetCore.Auth.Jwt.Models;
+
+namespace Psalms.AspNetCore.Auth.Jwt.Repository.RefreshToken.Memory;
+
+internal class RefreshTokenRepositoryInMemory(IMemoryCache cache) : IPsalmsRefreshTokenRepository
+{
+    public Task DeleteRefreshTokenAsync(string token)
+    {
+        cache.Remove(token);
+        return Task.CompletedTask;
+    }   
+
+    public Task<bool> RefreshTokenExistAsync(string token)
+    {
+        return Task.FromResult(cache.Get(token) is not null);
+    }
+
+    public Task SaveRefreshTokenAsync(RefreshTokenModel model)
+    {
+        cache.Set(model.RefreshToken!, model);
+        return Task.CompletedTask;
+    }
+}

--- a/Psalms.AspNetCore.Auth.Jwt/Services/PsalmsJwtTokenService.AccessToken.cs
+++ b/Psalms.AspNetCore.Auth.Jwt/Services/PsalmsJwtTokenService.AccessToken.cs
@@ -1,0 +1,48 @@
+﻿using Psalms.AspNetCore.Auth.Jwt.Models;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+
+namespace Psalms.Auth.Jwt;
+
+public partial class PsalmsJwtTokenService
+{
+    /// <summary>
+    /// Generates a JWT token using the given claims and the configuration values.
+    /// </summary>
+    /// <param name="claims">An array of claims to include in the token payload.</param>
+    /// <returns>A signed JWT token as a string.</returns>
+    public Task<string> GenerateAccessTokenAsync(IEnumerable<Claim>? claims)
+    {
+        DateTime? expires = null;
+
+        if (_configuration["JWT:Expires"] is string expiresValue && int.TryParse(expiresValue, out int hours))
+            expires = DateTime.UtcNow.AddHours(hours);
+
+        var token = new JwtSecurityToken(
+            issuer: _configuration["JWT:Issuer"],
+            audience: _configuration["JWT:Audience"],
+            claims: claims,
+            expires: expires,
+            signingCredentials: _credentials.Value
+        );
+
+        return Task.FromResult(_tokenHandler.Value.WriteToken(token));
+    }
+
+    /// <summary>
+    /// Generates an <see cref="AuthResponse"/> containing an access token and a refresh token.
+    /// </summary>
+    /// <param name="claims">The claims to include in the generated access token.</param>
+    /// <returns>
+    /// A task that represents the asynchronous operation. The task result contains an <see cref="AuthResponse"/> 
+    /// with the generated access token and refresh token model.
+    /// </returns>
+    public async Task<AuthResponse> GetAuthResponseAsync(IEnumerable<Claim>? claims)
+    {
+        return new()
+        {
+            AccessToken       = await GenerateAccessTokenAsync(claims),
+            RefreshTokenModel = await GenerateRefreshTokenAsync()
+        };
+    }
+}

--- a/Psalms.AspNetCore.Auth.Jwt/Services/PsalmsJwtTokenService.Refresh.cs
+++ b/Psalms.AspNetCore.Auth.Jwt/Services/PsalmsJwtTokenService.Refresh.cs
@@ -1,0 +1,69 @@
+﻿using Psalms.AspNetCore.Auth.Jwt.Models;
+using System.Security.Cryptography;
+
+namespace Psalms.Auth.Jwt;
+
+/// <summary>
+/// Service responsible for generating and validating JWT refresh tokens,
+/// including refreshing authentication tokens.
+/// </summary>
+public partial class PsalmsJwtTokenService
+{
+    /// <summary>
+    /// Generates a new secure refresh token asynchronously and saves it to the repository if available.
+    /// </summary>
+    /// <returns>A <see cref="RefreshTokenModel"/> containing the generated refresh token.</returns>
+    public async Task<RefreshTokenModel> GenerateRefreshTokenAsync()
+    {
+        var randomNumber = new byte[32];
+        using var rng = RandomNumberGenerator.Create();
+        rng.GetBytes(randomNumber);
+
+        var refreshToken = Convert.ToBase64String(randomNumber);
+
+        RefreshTokenModel model = new() { RefreshToken = refreshToken };
+
+        if (_refreshTokenRepository is not null)
+            await _refreshTokenRepository.SaveRefreshTokenAsync(model);
+
+        return await Task.FromResult(model);
+    }
+
+    /// <summary>
+    /// Refreshes the authentication tokens based on the provided authentication response.
+    /// Validates the refresh token, deletes the old token, and generates new tokens.
+    /// </summary>
+    /// <param name="auth">The current authentication response containing access and refresh tokens.</param>
+    /// <returns>A new <see cref="AuthResponse"/> with updated access and refresh tokens.</returns>
+    public async Task<AuthResponse> RefreshTokenAsync(AuthResponse auth)
+    {
+        await ValidateAuthResponseAsync(auth);
+
+        var claims = await GetClaimsPrincipalInExpiredTokenAsync(auth.AccessToken!);
+
+        await _refreshTokenRepository!.DeleteRefreshTokenAsync(auth.RefreshTokenModel!.RefreshToken!);
+
+        return await GetAuthResponseAsync(claims.Claims);
+    }
+
+    /// <summary>
+    /// Validates the given authentication response for the presence and existence of tokens.
+    /// Throws exceptions if any validation fails.
+    /// </summary>
+    /// <param name="auth">The authentication response to validate.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    /// <exception cref="NullReferenceException">Thrown when tokens are null.</exception>
+    /// <exception cref="Exception">Thrown when repository is not found or refresh token does not exist.</exception>
+    private async Task ValidateAuthResponseAsync(AuthResponse auth)
+    {
+        if (auth.AccessToken is null || auth.RefreshTokenModel is null)
+            throw new NullReferenceException("Auth response is null");
+
+        if (auth.RefreshTokenModel.RefreshToken is null) throw new NullReferenceException("Refresh token is null.");
+
+        if (_refreshTokenRepository is null) throw new Exception("Repository not found");
+
+        if (!await _refreshTokenRepository.RefreshTokenExistAsync(auth.RefreshTokenModel.RefreshToken))
+            throw new Exception("refresh token no exist");
+    }
+}

--- a/Psalms.AspNetCore.Auth.Jwt/Services/PsalmsJwtTokenService.Validation.cs
+++ b/Psalms.AspNetCore.Auth.Jwt/Services/PsalmsJwtTokenService.Validation.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+
+namespace Psalms.Auth.Jwt;
+
+public partial class PsalmsJwtTokenService
+{
+    /// <summary>
+    /// Converts a raw key string into a <see cref="SymmetricSecurityKey"/> using UTF-8 encoding.
+    /// </summary>
+    /// <param name="key">The key string from configuration.</param>
+    /// <returns>An instance of <see cref="SymmetricSecurityKey"/>.</returns>
+    /// <exception cref="Exception">Thrown if the key is null or not found.</exception>
+    private static SymmetricSecurityKey GetSymmetricSecurityKeyLazy(string? key)
+        => new(Encoding.UTF8.GetBytes(key ?? throw new Exception("Key not found")));
+
+    /// <summary>
+    /// Extracts the <see cref="ClaimsPrincipal"/> from an expired JWT access token.
+    /// This method validates the token signature but ignores token expiration to retrieve claims.
+    /// </summary>
+    /// <param name="token">The expired JWT access token.</param>
+    /// <returns>A task containing the <see cref="ClaimsPrincipal"/> extracted from the token.</returns>
+    /// <exception cref="Exception">Thrown when the token is invalid or uses an unexpected algorithm.</exception>
+    private Task<ClaimsPrincipal> GetClaimsPrincipalInExpiredTokenAsync(string token)
+    {
+        var tokenParameters = GetValidationParameters(_configuration);
+
+        var claims = _tokenHandler.Value.ValidateToken(token, tokenParameters, out var securityToken);
+
+        if (securityToken is not JwtSecurityToken jwtSecurity ||
+            !jwtSecurity.Header.Alg.Equals(SecurityAlgorithms.HmacSha256, StringComparison.InvariantCultureIgnoreCase))
+            throw new Exception("Invalid token.");
+
+        return Task.FromResult(claims);
+    }
+
+    /// <summary>
+    /// Creates <see cref="TokenValidationParameters"/> for validating JWT tokens.
+    /// Pulls settings from the configuration, including issuer, audience, and signing key.
+    /// </summary>
+    /// <param name="configuration">The application configuration containing JWT settings.</param>
+    /// <returns>A configured <see cref="TokenValidationParameters"/> object.</returns>
+    /// <exception cref="Exception">Thrown when the signing key is not found in configuration.</exception>
+    internal static TokenValidationParameters GetValidationParameters(IConfiguration configuration)
+    {
+        var key = configuration["JWT:Key"] ?? throw new Exception("Key not found");
+
+        return new TokenValidationParameters
+        {
+            ValidateIssuer           = !string.IsNullOrEmpty(configuration["JWT:Issuer"]),
+            ValidateAudience         = !string.IsNullOrEmpty(configuration["JWT:Audience"]),
+            ValidateLifetime         = !string.IsNullOrEmpty(configuration["JWT:Expires"]),
+            ValidateIssuerSigningKey = !string.IsNullOrEmpty(key),
+            IssuerSigningKey         = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key))
+        };
+    }
+
+}


### PR DESCRIPTION
## 🔀 Pull Request – Initial Implementation of `PsalmsJwtTokenService`

### 📋 Description

This PR introduces the `Psalms.AspNetCore.Auth.Jwt` library, designed to **abstract JWT authentication logic** in [ASP.NET](http://asp.net/) Core APIs.

It provides a clean, extensible, and reusable service for generating, validating, and refreshing access and refresh tokens, with pluggable repository strategies.

---

### ✅ Features

- 🔐 Generate **JWT access tokens** based on claims.
- 🔁 Generate and persist secure **refresh tokens**.
- 🔄 Support for **token renewal** using a validated refresh token.
- 🧩 Plug-and-play support for different token repositories:
    - EF Core (`IPsalmsRefreshTokenEFContext`)
    - In-Memory (`IMemoryCache`)
    - Custom (`IPsalmsRefreshTokenRepository`)
- 🔎 Extract `ClaimsPrincipal` from expired access tokens.

---

### ⚙️ Required Configuration (`appsettings.json`)

```json

"JWT": {
  "Key": "your-secret-key-here",
  "Issuer": "your-issuer",
  "Audience": "your-audience",
  "Expires": "8" // in hours (optional)
}

```

---

### 📁 File Structure

- `PsalmsJwtTokenService.cs` – constructors and service wiring.
- `AccessToken.cs` – access token generation logic.
- `Refresh.cs` – refresh token creation and renewal logic.
- `Validation.cs` – validation and claim extraction helpers.
- `AuthResponse.cs` – DTO for carrying access and refresh tokens.
- `RefreshTokenModel.cs` – model representing a refresh token.

---

### 💡 Usage Example

### 1. Dependency Injection (`Program.cs`)

```csharp

builder.Services.AddScoped<PsalmsJwtTokenService>(sp =>
{
    var config = sp.GetRequiredService<IConfiguration>();
    var memoryCache = sp.GetRequiredService<IMemoryCache>();

    return new PsalmsJwtTokenService(config, memoryCache);
});

```

### 2. Generate tokens after login

```csharp

var claims = new List<Claim>
{
    new(ClaimTypes.NameIdentifier, user.Id.ToString()),
    new(ClaimTypes.Name, user.Username),
};

var auth = await _jwtService.GetAuthResponseAsync(claims);

// auth.AccessToken -> signed JWT
// auth.RefreshTokenModel.RefreshToken -> secure refresh token

```

### 3. Refresh token usage

```csharp

var refreshedAuth = await _jwtService.RefreshTokenAsync(previousAuth);

```

Closes #5 
Closes #4 